### PR TITLE
Applying attributes from Otel resources to Azure Monitor traces, logs

### DIFF
--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/MessageData.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-
 using Azure.Core;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
 
@@ -12,11 +10,11 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 {
     internal partial class MessageData
     {
-        public MessageData(int version, LogRecord logRecord) : base(version)
+        public MessageData(int version, LogRecord logRecord, AzureMonitorResource? resource = null) : base(version)
         {
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
-            Message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties).Truncate(SchemaConstants.MessageData_Message_MaxLength);
+            Message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties, resource).Truncate(SchemaConstants.MessageData_Message_MaxLength);
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
         }
     }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryExceptionData.cs
@@ -16,7 +16,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
     {
         internal const int MaxExceptionCountToSave = 10;
 
-        public TelemetryExceptionData(int version, LogRecord logRecord) : base(version)
+        public TelemetryExceptionData(int version, LogRecord logRecord, AzureMonitorResource? resource = null) : base(version)
         {
             if (logRecord.Exception == null)
             {
@@ -26,7 +26,7 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             Properties = new ChangeTrackingDictionary<string, string>();
             Measurements = new ChangeTrackingDictionary<string, double>();
 
-            var message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties);
+            var message = LogsHelper.GetMessageAndSetProperties(logRecord, Properties, resource);
 
             SeverityLevel = LogsHelper.GetSeverityLevel(logRecord.LogLevel);
             ProblemId = LogsHelper.GetProblemId(logRecord.Exception).Truncate(SchemaConstants.ExceptionData_ProblemId_MaxLength);

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Customizations/Models/TelemetryItem.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 using Azure.Monitor.OpenTelemetry.Exporter.Internals;
@@ -67,43 +65,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
             {
                 SampleRate = sampleRate;
             }
-
-            SetTagsFrom(activity, resource);
-        }
-
-        private void SetTagsFrom(Activity activity, AzureMonitorResource? resource)
-        {
-            SetTagsFrom(resource);
-
-            // Activity-level tags trump resource-level tags.
-            foreach (KeyValuePair<string, string?> r in activity.Tags.Where(i => !Tags.ContainsKey(i.Key) && i.Value is not null))
-            {
-                Tags[r.Key] = r.Value!;
-            }
-        }
-
-        private void SetTagsFrom(LogRecord logRecord, AzureMonitorResource? resource)
-        {
-            SetTagsFrom(resource);
-
-            if (logRecord.Attributes is not null)
-            {
-                foreach (KeyValuePair<string, object?> r in logRecord.Attributes.Where(i => !Tags.ContainsKey(i.Key) && i.Value is not null))
-                {
-                    Tags[r.Key] = r.Value!.ToString();
-                }
-            }
-        }
-
-        private void SetTagsFrom(AzureMonitorResource? resource)
-        {
-            if (resource is not null)
-            {
-                foreach (KeyValuePair<string, object> i in resource.OtelResource.Attributes)
-                {
-                    Tags[i.Key] = i.Value.ToString();
-                }
-            }
         }
 
         public TelemetryItem(string name, TelemetryItem telemetryItem, ActivitySpanId activitySpanId, ActivityKind kind, DateTimeOffset activityEventTimeStamp) :
@@ -144,8 +105,6 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Models
 
             InstrumentationKey = instrumentationKey;
             SetResourceSdkVersionAndIkey(resource, instrumentationKey);
-
-            SetTagsFrom(logRecord, resource);
         }
 
         public TelemetryItem(DateTime time, AzureMonitorResource? resource, string instrumentationKey) : this("Metric", FormatUtcTimestamp(time))

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorResource.cs
@@ -3,14 +3,24 @@
 
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 
+using OpenTelemetry.Resources;
+
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals
 {
     internal sealed class AzureMonitorResource
     {
+        public AzureMonitorResource() : this(ResourceBuilder.CreateEmpty()) { }
+
+        public AzureMonitorResource(ResourceBuilder resourceBuilder) : this(resourceBuilder.Build()) { }
+
+        public AzureMonitorResource(Resource otelResource) => OtelResource = otelResource;
+
         internal string? RoleName { get; set; }
 
         internal string? RoleInstance { get; set; }
 
         internal TelemetryItem? MetricTelemetry { get; set; }
+
+        internal Resource OtelResource { get; private set; }
     }
 }

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/ResourceExtensions.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter.Internals.Platform;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
+
 using OpenTelemetry.Resources;
 
 namespace Azure.Monitor.OpenTelemetry.Exporter.Internals;
@@ -26,7 +28,7 @@ internal static class ResourceExtensions
             return null;
         }
 
-        AzureMonitorResource azureMonitorResource = new AzureMonitorResource();
+        AzureMonitorResource azureMonitorResource = new(resource);
         MetricsData? metricsData = null;
         AksResourceProcessor? aksResourceProcessor = null;
         string? serviceName = null;

--- a/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
+++ b/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/tests/Integration.Tests/RequestTelemetryTests.cs
@@ -10,8 +10,11 @@ using System.Threading.Tasks;
 using Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests.TestFramework;
 using Azure.Monitor.OpenTelemetry.Exporter.Models;
 using Azure.Monitor.OpenTelemetry.Exporter.Tests.CommonTestFramework;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 using Xunit;
@@ -42,9 +45,17 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
             // SETUP WEBAPPLICATION WITH OPENTELEMETRY
             var builder = WebApplication.CreateBuilder();
             builder.Services.AddOpenTelemetry()
+                .ConfigureResource(rb => rb.AddService("my-service1",
+                        "my-namespace1", "my-version1", serviceInstanceId: "my-instance-id1"))
                 .WithTracing(builder => builder
                     .AddAspNetCoreInstrumentation()
-                    .AddAzureMonitorTraceExporterForTest(out telemetryItems));
+                    .ConfigureResource(rb => rb.AddService("my-service2",
+                        "my-namespace2", "my-version2", serviceInstanceId: "my-instance-id2"))
+                    .AddAzureMonitorTraceExporterForTest(out telemetryItems)
+                    .ConfigureResource(rb => rb.AddService("my-service3",
+                        "my-namespace3", "my-version3", serviceInstanceId: "my-instance-id3")))
+                .ConfigureResource(rb => rb.AddService("my-service4",
+                        "my-namespace4", "my-version4", serviceInstanceId: "my-instance-id4"));
 
             var app = builder.Build();
             app.MapGet("/", () =>
@@ -73,6 +84,69 @@ namespace Azure.Monitor.OpenTelemetry.Exporter.Integration.Tests
                 telemetryItem: telemetryItem,
                 expectedResponseCode: "200",
                 expectedUrl: TestServerUrl);
+        }
+
+        /// <summary>
+        /// This test validates that when an app instrumented with the AzureMonitorExporter receives an HTTP request,
+        /// A TelemetryItem is created matching that request.
+        /// </summary>
+        [Fact]
+        public async Task VerifyRequestTelemetryWithResourceAttributes()
+        {
+            string testValue = Guid.NewGuid().ToString();
+
+            List<TelemetryItem>? telemetryItems = null;
+
+            // SETUP WEBAPPLICATION WITH OPENTELEMETRY
+            var builder = WebApplication.CreateBuilder();
+            builder.Services.AddOpenTelemetry()
+                .WithTracing(builder => builder
+                    .AddAspNetCoreInstrumentation()
+                    .AddAzureMonitorTraceExporterForTest(out telemetryItems))
+                // Add a custom service to the otel pipeline; this service's attributes should decorate everything
+                // pushing through otel automatically.
+                .ConfigureResource(rb => rb
+                    .AddService("my-service", "my-namespace", "my-version", serviceInstanceId: "my-instance-id")
+                    // Add some custom attributes, too.
+                    .AddAttributes(new[] {
+                        new KeyValuePair<string, object>("my-attribute", "unittest"),
+                        new KeyValuePair<string, object>("my-flag", false)
+                    }));
+
+            var app = builder.Build();
+            app.MapGet("/", () =>
+            {
+                return "Response from Test Server";
+            });
+
+            _ = app.RunAsync(TestServerUrl);
+
+            // ACT
+            using var httpClient = new HttpClient();
+            var res = await httpClient.GetStringAsync(TestServerUrl).ConfigureAwait(false);
+            Assert.True(res.Equals("Response from Test Server"), "If this assert fails, the in-process test server is not running.");
+
+            // Shutdown
+            //response.EnsureSuccessStatusCode();
+            Assert.NotNull(telemetryItems);
+            this.WaitForActivityExport(telemetryItems);
+
+            // Assert
+            Assert.True(telemetryItems.Any(), "test project did not capture telemetry");
+            var telemetryItem = telemetryItems.Last()!;
+            this.telemetryOutput.Write(telemetryItem);
+
+            AssertRequestTelemetry(
+                telemetryItem: telemetryItem,
+                expectedResponseCode: "200",
+                expectedUrl: TestServerUrl);
+
+            Assert.Equal("my-service", telemetryItem.Tags["service.name"]);
+            Assert.Equal("my-namespace", telemetryItem.Tags["service.namespace"]);
+            Assert.Equal("my-version", telemetryItem.Tags["service.version"]);
+            Assert.Equal("my-instance-id", telemetryItem.Tags["service.instance.id"]);
+            Assert.Equal("unittest", telemetryItem.Tags["my-attribute"]);
+            Assert.Equal(bool.FalseString, telemetryItem.Tags["my-flag"]);
         }
 #endif
     }


### PR DESCRIPTION
This PR lights up the capability to apply any `Attributes` added on an OpenTelemetry `Resource` object to all telemetry events logged to Azure Monitor.

Example:

```csharp
services.AddOpenTelemetry()
    .UseAzureMonitor()
    .ConfigureResource(rb => rb.AddAttributes([
        new KeyValuePair<string, object>("otelPipeline", true)
    ]))
```

Will result in all telemetry sent through the pipeline having a property of `otelPipeline` with value `true` logged to Azure Monitor.

![image](https://github.com/brandonh-msft/azure-sdk-for-net/assets/20270743/a8812030-b072-426f-a81f-2113c2b3db3e)

This is the desired behavior of configured `Resource` objects in Open Telemetry.